### PR TITLE
[releng-tools] build-package: allow branch override using a tag

### DIFF
--- a/build_package.sh
+++ b/build_package.sh
@@ -234,7 +234,11 @@ case "${BUILD_TYPE}" in
 		ARGS="${ARGS} --branch ${BRANCH} --rolling-release next"
 		;;
 	"staging")
-		ARGS="${ARGS} --branch ${BRANCH}"
+		if [ -n "${RELENG_TAG_FULL}" ]; then
+			ARGS="${ARGS} --tag ${RELENG_TAG_FULL}"
+		else
+			ARGS="${ARGS} --branch ${BRANCH}"
+		fi
 		;;
 esac
 # NOTE: On Travis CI we're stuck to depth 50 unless we unshallow.


### PR DESCRIPTION
The build-package tool uses a branch name by default as base to calculate the package version string.

This change allows to override this default behavior by using a tag name instead.

To use this feature just call the build-backage tool preceded by the RELENG_TAG_FULL=<tag_name> variable declaration.